### PR TITLE
Bump version to v0.1.0.beta5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    track_ballast (0.1.0.beta4)
+    track_ballast (0.1.0.beta5)
       activerecord (>= 6.1, < 8.0)
       activesupport (>= 6.1, < 8.0)
 

--- a/lib/track_ballast/version.rb
+++ b/lib/track_ballast/version.rb
@@ -1,3 +1,3 @@
 module TrackBallast
-  VERSION = "0.1.0.beta4"
+  VERSION = "0.1.0.beta5"
 end


### PR DESCRIPTION
This is to assist with internal testing, which previously did not download v0.1.0.beta4 from rubygems.org

There are no other changes.  This version bump is happening simply to confirm that we're using rubygems.org and not cached copies of v0.1.0.beta4