### PR TITLE
Specify supported Ruby versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Changelog
 =========
 
-## 0.1.0.beta1
+## 0.1.0
 
 * First external release
-* Add `Callable`
-* Add `UuidManagement`
+* Added support for Ruby 3.0 - 3.3
+* Added `Callable`
+* Added `UuidManagement`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    track_ballast (0.1.0.beta5)
+    track_ballast (0.1.0.beta6)
       activerecord (>= 6.1, < 8.0)
       activesupport (>= 6.1, < 8.0)
 

--- a/lib/track_ballast/version.rb
+++ b/lib/track_ballast/version.rb
@@ -1,3 +1,3 @@
 module TrackBallast
-  VERSION = "0.1.0.beta5"
+  VERSION = "0.1.0.beta6"
 end

--- a/track_ballast.gemspec
+++ b/track_ballast.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Small supporting units of Ruby to use with Rails"
   spec.homepage = "https://github.com/doximity/track_ballast"
   spec.license = "APACHE-2.0"
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
This is now tested in CI.  (See also: https://github.com/doximity/track_ballast/pull/9)

Closes #6 