### PR TITLE
Fix CONTRIBUTING link for rubydoc.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ find spec -name '*_spec.rb' -exec bundle exec rspec {} \;
 
 ## Contributing
 
-1. See [CONTRIBUTING.md](./CONTRIBUTING.md)
+1. See [CONTRIBUTING.md](https://github.com/doximity/track_ballast/blob/master/CONTRIBUTING.md)
 2. Fork it ( https://github.com/doximity/track_ballast/fork )
 3. Create your feature branch (`git checkout -b my-new-feature`)
 4. Commit your changes (`git commit -am 'Add some feature'`)


### PR DESCRIPTION
The CONTRIBUTING link at https://www.rubydoc.info/gems/track_ballast results in a 404 because it links to https://www.rubydoc.info/gems/CONTRIBUTING.md

![Screenshot 2024-02-13 at 10 56 12](https://github.com/doximity/track_ballast/assets/5323/efd70acc-b858-4306-8b52-e4ad516e34a1)
