### PR TITLE
[MOFODCORE-2863-rails8-support] add rails 8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ commands:
         - run:
             name: Gem version after upgrade
             command: |
+              cat Gemfile.lock
               read -r target_gemname target_version \<<< $( echo "<< parameters.gem-version >>" | sed 's/\(.*\)-\([0-9]\{1,3\}\(\.[0-9]\{1,3\}\)*\)/\1 \2/g')
               version=$(bundle list | sed -n "s/[[:space:]]*\* $target_gemname (\(.*\))/\1/p")
               if [[ -z "$version" ]]; then
@@ -228,12 +229,10 @@ workflows:
               path: tmp/test-results
         matrix:
           parameters:
-            ruby-version:
-            - '3.0'
-            - '3.1'
-            - '3.2'
-            - '3.3'
-            gem-version:
-            - rails-6.1.7
-            - rails-7.0.8
-            - rails-7.1.3
+            ruby-version: ['3.0', '3.1', '3.2', '3.3']
+            gem-version: ['rails-7.0.8', 'rails-7.1.3', 'rails-8.0.2']
+          exclude:
+            - ruby-version: '3.0'
+              gem-version: 'rails-8.0.2'
+            - ruby-version: '3.1'
+              gem-version: 'rails-8.0.2'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,12 @@ commands:
               read -r target_gemname target_version \<<< $( echo "<< parameters.gem-version >>" | sed 's/\(.*\)-\([0-9]\{1,3\}\(\.[0-9]\{1,3\}\)*\)/\1 \2/g')
               gem install $target_gemname -i /tmp/repo --no-document -v $target_version
 
+              # Install sqlite3 2.1.0 if we're using Rails 8
+              if [[ "$target_gemname" = "rails" && "$target_version" =~ ^8\. ]]; then
+                echo "Detected Rails 8.x, installing sqlite3 2.1.0"
+                gem install sqlite3 -i /tmp/repo --no-document -v 2.1.0
+              fi
+
               echo 'Delete any gems matching the newly installed ones from the existing cache'
               for line in $(ls /tmp/repo/cache | grep gem); do
                 read -r gemname version \<<< $( echo $line | sed 's/\(.*\)-\([0-9]\{1,3\}\(\.[0-9]\{1,3\}\)*\)[^0-9\.]*.*.gem/\1 \2/g')
@@ -131,7 +137,6 @@ commands:
         - run:
             name: Gem version after upgrade
             command: |
-              cat Gemfile.lock
               read -r target_gemname target_version \<<< $( echo "<< parameters.gem-version >>" | sed 's/\(.*\)-\([0-9]\{1,3\}\(\.[0-9]\{1,3\}\)*\)/\1 \2/g')
               version=$(bundle list | sed -n "s/[[:space:]]*\* $target_gemname (\(.*\))/\1/p")
               if [[ -z "$version" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 ## 0.3.0
 
 * Added support for Rails 8
-* Updated ActiveRecord and ActiveSupport dependencies to support Rails 6.1 - 8.x
+* Updated ActiveRecord and ActiveSupport dependencies to support Rails 7.0 - 8.x
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 0.3.0
+
+* Added support for Rails 8
+* Updated ActiveRecord and ActiveSupport dependencies to support Rails 6.1 - 8.x
+
 ## 0.2.0
 
 * Added `redis` dependency

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    track_ballast (0.2.0.beta1)
-      activerecord (>= 6.1, < 8.0)
-      activesupport (>= 6.1, < 8.0)
+    track_ballast (0.3.0)
+      activerecord (>= 6.1, < 9.0)
+      activesupport (>= 6.1, < 9.0)
       redis (>= 4.8, < 6.0)
 
 GEM
@@ -143,6 +143,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     track_ballast (0.3.0)
-      activerecord (>= 6.1, < 9.0)
-      activesupport (>= 6.1, < 9.0)
+      activerecord (>= 7.0, < 9.0)
+      activesupport (>= 7.0, < 9.0)
       redis (>= 4.8, < 6.0)
 
 GEM

--- a/lib/track_ballast/version.rb
+++ b/lib/track_ballast/version.rb
@@ -1,3 +1,3 @@
 module TrackBallast
-  VERSION = "0.2.0.beta1"
+  VERSION = "0.3.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "bundler/setup"
 require "track_ballast/logger"
 
+require "logger"
 require "active_record"
 
 RSpec.configure do |config|

--- a/track_ballast.gemspec
+++ b/track_ballast.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 6.1", "< 8.0"
-  spec.add_dependency "activesupport", ">= 6.1", "< 8.0"
+  spec.add_dependency "activerecord", ">= 6.1", "< 9.0"
+  spec.add_dependency "activesupport", ">= 6.1", "< 9.0"
   spec.add_dependency "redis", ">= 4.8", "< 6.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "guard"

--- a/track_ballast.gemspec
+++ b/track_ballast.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 6.1", "< 9.0"
-  spec.add_dependency "activesupport", ">= 6.1", "< 9.0"
+  spec.add_dependency "activerecord", ">= 7.0", "< 9.0"
+  spec.add_dependency "activesupport", ">= 7.0", "< 9.0"
   spec.add_dependency "redis", ">= 4.8", "< 6.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "guard"


### PR DESCRIPTION
This PR does the following:

* Update gem to support Rails 8
* Drops gem support for Rails 6.1
* Bumps version to 0.3.0 in preparation for gem release.